### PR TITLE
A litttle cleanup, docs and adding rgw install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,24 +29,29 @@ Known to Work on:
     - 75 GB Standard SATA block device attached as /dev/xvdb
 ```    
 
-### Install ansible
+### Boot Strap the Host
+Use **bootstrap.sh** to stage the host:
+
 Add ansible repo and run update package lists
 ```
 sudo apt-add-repository ppa:ansible/ansible
 sudo apt-get update
 ```
-
-Install ansible
+Install ansible 
 ```
 sudo apt-get install -y ansible
 ```
-
-### To build
-
 Create a passwordless ssh-key
 ```
 su - $USER -c "echo |ssh-keygen -t rsa"
+cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
 ```
+Disable password entry
+```
+sed -i '/PasswordAuthentication yes/c\PasswordAuthentication no' /etc/ssh/sshd_config##
+```
+
+### To Create the CephAIO
 
 ```
 cd CephAIO

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install ansible
 ```
 sudo apt-get install -y ansible
 ```
-Create a passwordless ssh-key
+Create a passwordless ssh-key and copy the key to itself
 ```
 su - $USER -c "echo |ssh-keygen -t rsa"
 cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
@@ -69,10 +69,15 @@ After using the teardown playbook, ensure that the ceph disk has been completely
 
 ` ansible-playbook -i inventory cleanup.yml `
 
-If the containers and drives are created but the installation of ceph fails then ` cleanup.yml ` will stop and destory the containers then remove the 3 partitions from the external drive and then run the ' shred ` command.  This ability to basically reset the host back to clean state with minimum effort if an error installing ceph happens.
+If the containers and drives are created but the installation of ceph fails then ` cleanup.yml ` will stop and destory the containers then remove the 3 partitions from the external drive and then run the ' shred ` command.  This provides the ability to reset the host back to a clean state if an error installing ceph happens.
+
+### Tests
+
+The directory  **tests** contains information on how to test the success of some installed components.  
 
 TO DO: 
 
 - Add variable to control the number of osds deployed
 - Add variable to remove the hardcoded /dev/xvdb
+
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The goal of this project was to create an all in one enviroment of ceph that res
 | cephosd1  | 10.0.3.53 | ceph osd host                           |
 | cephosd2  | 10.0.3.54 | ceph osd host                           |
 | cephosd3  | 10.0.3.55 | ceph osd host                           |
+| cephrgw   | 10.0.3.56 | ceph rados gateway host                 |
 -------------------------------------------------------------------
 ```
 
@@ -30,6 +31,11 @@ Known to Work on:
 
 ### To build
 
+Create a passwordless ssh-key
+```
+su - $USER -c "echo |ssh-keygen -t rsa"
+```
+
 ```
 cd CephAIO
 bash bootstrap.sh
@@ -42,6 +48,11 @@ ansible-playbook -i inventory build.yml
 
 After using the teardown playbook, ensure that the ceph disk has been completely wiped. Ceph leaves some residual data that interferes with future deployments. The teardown playbook currently uses ` shred ` to perform the data wipe (this takes awhile), but I am pretty sure that removing the block device and adding a new one would accomplish the same end result.
 
+### Clean Up
+
+` ansible-playbook -i inventory cleanup.yml `
+
+If the containers and drives are created but the installation of ceph fails then ` cleanup.yml ` will stop and destory the containers then remove the 3 partitions from the external drive and then run the ' shred ` command.  This ability to basically reset the host back to clean state with minimum effort if an error installing ceph happens.
 
 TO DO: 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ Known to Work on:
     - 75 GB Standard SATA block device attached as /dev/xvdb
 ```    
 
+### Install ansible
+Add ansible repo and run update package lists
+```
+sudo apt-add-repository ppa:ansible/ansible
+sudo apt-get update
+```
+
+Install ansible
+```
+sudo apt-get install -y ansible
+```
+
 ### To build
 
 Create a passwordless ssh-key

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,7 +7,7 @@ apt-add-repository ppa:ansible/ansible
 apt-get update
 apt-get install ansible
 
-# Crate a key-pair Copy public key to self
+# Create a key-pair and copy public key to self
 su - $USER -c "echo |ssh-keygen -t rsa"
 cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,7 +7,8 @@ apt-add-repository ppa:ansible/ansible
 apt-get update
 apt-get install ansible
 
-# Copy public key to self
+# Crate a key-pair Copy public key to self
+su - $USER -c "echo |ssh-keygen -t rsa"
 cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
 
 # Disable password entry

--- a/cleanup.yml
+++ b/cleanup.yml
@@ -1,0 +1,7 @@
+---
+
+- hosts: physical_host
+  roles:
+    - teardown
+
+

--- a/inventory
+++ b/inventory
@@ -19,3 +19,6 @@ cephosd1
 cephosd1
 cephosd2
 cephosd3
+
+[rgws]
+cephmon

--- a/inventory
+++ b/inventory
@@ -21,4 +21,4 @@ cephosd2
 cephosd3
 
 [rgws]
-cephmon
+cephrgw

--- a/roles/admin_setup/tasks/admin_setup.yml
+++ b/roles/admin_setup/tasks/admin_setup.yml
@@ -26,4 +26,5 @@
     - { container: "cephosd1" , ip: "10.0.3.53" }
     - { container: "cephosd2" , ip: "10.0.3.54" }
     - { container: "cephosd3" , ip: "10.0.3.55" }
+    - { container: "cephrgw" , ip: "10.0.3.56" }
 

--- a/roles/build/tasks/create_containers.yml
+++ b/roles/build/tasks/create_containers.yml
@@ -12,6 +12,7 @@
     - cephosd1
     - cephosd2
     - cephosd3
+    - cephrgw
 
 - name: Assign IPs to containers
   lineinfile:
@@ -24,6 +25,7 @@
     - { container: '/var/lib/lxc/cephosd1/config', IP: '10.0.3.53' }
     - { container: '/var/lib/lxc/cephosd2/config', IP: '10.0.3.54' }
     - { container: '/var/lib/lxc/cephosd3/config', IP: '10.0.3.55' } 
+    - { container: '/var/lib/lxc/cephrgw/config', IP: '10.0.3.56' } 
 
 - name: Start conainters
   lxc_container:
@@ -35,6 +37,7 @@
     - cephosd1
     - cephosd2
     - cephosd3
+    - cephrgw
 
 - name: Create mountpoint for osd disk
   lxc_container:
@@ -67,6 +70,7 @@
     - cephosd1
     - cephosd2
     - cephosd3
+    - cephrgw
 
 - name: Install python in containers
   lxc_container:
@@ -80,6 +84,7 @@
     - cephosd1
     - cephosd2
     - cephosd3
+    - cephrgw
 
 - name: Create .ssh directory
   file:
@@ -93,6 +98,7 @@
     - /var/lib/lxc/cephosd1/rootfs/root/.ssh
     - /var/lib/lxc/cephosd2/rootfs/root/.ssh
     - /var/lib/lxc/cephosd3/rootfs/root/.ssh
+    - /var/lib/lxc/cephrgw/rootfs/root/.ssh
 
 - name: Modify permissions of .ssh in container
   lxc_container:
@@ -105,6 +111,7 @@
     - cephosd1
     - cephosd2
     - cephosd3
+    - cephrgw
 
 - name: Add authorized_keys file to containers
   copy:
@@ -119,6 +126,7 @@
     - /var/lib/lxc/cephosd1/rootfs/root/.ssh/authorized_keys
     - /var/lib/lxc/cephosd2/rootfs/root/.ssh/authorized_keys
     - /var/lib/lxc/cephosd3/rootfs/root/.ssh/authorized_keys
+    - /var/lib/lxc/cephrgw/rootfs/root/.ssh/authorized_keys
 
 - name: Add physical host key to container authorized_keys file
   shell: cat ~/.ssh/id_rsa.pub >> "{{ item }}"
@@ -128,6 +136,7 @@
     - /var/lib/lxc/cephosd1/rootfs/root/.ssh/authorized_keys
     - /var/lib/lxc/cephosd2/rootfs/root/.ssh/authorized_keys
     - /var/lib/lxc/cephosd3/rootfs/root/.ssh/authorized_keys
+    - /var/lib/lxc/cephrgw/rootfs/root/.ssh/authorized_keys
 
 - name: add ssh key to cephadmin container
   shell: cat ~/.ssh/id_rsa >> "{{ item }}"
@@ -153,6 +162,7 @@
     - cephosd1
     - cephosd2
     - cephosd3
+    - cephrgw
 
 - name: Restart containers
   lxc_container:
@@ -164,6 +174,7 @@
     - cephosd1
     - cephosd2
     - cephosd3
+    - cephrgw
 
 #- name: wait for container ssh
 # wait_for: port=22 host= "{{ item }}" search_regex=OpenSSH delay=10
@@ -174,3 +185,4 @@
 #    - cephosd1
 #    - cephosd2
 #    - cephosd3
+#    - cephrgw

--- a/roles/build/tasks/update_hostfile.yml
+++ b/roles/build/tasks/update_hostfile.yml
@@ -9,4 +9,5 @@
     - { container: 'cephosd1', IP: '10.0.3.53'}
     - { container: 'cephosd2', IP: '10.0.3.54'}
     - { container: 'cephosd3', IP: '10.0.3.55'}
+    - { container: 'cephrgw', IP: '10.0.3.56'}
 

--- a/roles/install/tasks/install_mons.yml
+++ b/roles/install/tasks/install_mons.yml
@@ -36,4 +36,4 @@
   shell: /usr/bin/ceph-deploy install cephadmin cephmon cephosd1 cephosd2 cephosd3 cephrgw && echo "done" 
 
 - name: create ceph mons
-  shell: /usr/bin/ceph-deploy mon create-initial --overwrite-conf && echo "done"
+  shell: /usr/bin/ceph-deploy mon create-initial && echo "done"

--- a/roles/install/tasks/install_mons.yml
+++ b/roles/install/tasks/install_mons.yml
@@ -33,7 +33,7 @@
     state: present
 
 - name: install ceph cluster
-  shell: /usr/bin/ceph-deploy install cephadmin cephmon cephosd1 cephosd2 cephosd3 && echo "done" 
+  shell: /usr/bin/ceph-deploy install cephadmin cephmon cephosd1 cephosd2 cephosd3 cephrgw && echo "done" 
 
 - name: create ceph mons
-  shell: /usr/bin/ceph-deploy mon create-initial && echo "done"
+  shell: /usr/bin/ceph-deploy mon create-initial --overwrite-conf && echo "done"

--- a/roles/install/tasks/install_osds.yml
+++ b/roles/install/tasks/install_osds.yml
@@ -7,4 +7,4 @@
   shell: /usr/bin/ceph-deploy osd activate cephosd1:/mnt/xfsdisk cephosd2:/mnt/xfsdisk cephosd3:/mnt/xfsdisk && echo "done"
 
 - name: deploy admin keys
-  shell: /usr/bin/ceph-deploy admin cephadmin cephmon cephosd3 cephosd1 cephosd2 && echo "done" 
+  shell: /usr/bin/ceph-deploy admin cephadmin cephmon cephosd3 cephosd1 cephosd2 cephrgw && echo "done" 

--- a/roles/install/tasks/install_rgws.yml
+++ b/roles/install/tasks/install_rgws.yml
@@ -3,7 +3,7 @@
 - name: install ceph rgw
   shell: /usr/bin/ceph-deploy install --rgw cephrgw && echo "done"
 
-#  Seems to cause an error
+#  Seems to cause an error when trying to install
 # - name: promote cephrgw to an admin node
 #   shell: /usr/bin/ceph-deploy ceph-deploy admin cephrgw && echo "done"
 

--- a/roles/install/tasks/install_rgws.yml
+++ b/roles/install/tasks/install_rgws.yml
@@ -1,0 +1,10 @@
+---
+
+- name: install ceph rgw
+  shell: /usr/bin/ceph-deploy install --rgw cephrgw && echo "done"
+
+- name: promote cephrgw to an admin node
+  shell: /usr/bin/ceph-deploy ceph-deploy admin cephrgw && echo "done"
+
+- name: create the gateway instance
+  shell: /usr/bin/ceph-deploy rgw create cephrgw 

--- a/roles/install/tasks/install_rgws.yml
+++ b/roles/install/tasks/install_rgws.yml
@@ -7,4 +7,4 @@
   shell: /usr/bin/ceph-deploy ceph-deploy admin cephrgw && echo "done"
 
 - name: create the gateway instance
-  shell: /usr/bin/ceph-deploy rgw create cephrgw 
+  shell: /usr/bin/ceph-deploy rgw create cephrgw && echo "done"

--- a/roles/install/tasks/install_rgws.yml
+++ b/roles/install/tasks/install_rgws.yml
@@ -3,8 +3,9 @@
 - name: install ceph rgw
   shell: /usr/bin/ceph-deploy install --rgw cephrgw && echo "done"
 
-- name: promote cephrgw to an admin node
-  shell: /usr/bin/ceph-deploy ceph-deploy admin cephrgw && echo "done"
+#  Seems to cause an error
+# - name: promote cephrgw to an admin node
+#   shell: /usr/bin/ceph-deploy ceph-deploy admin cephrgw && echo "done"
 
 - name: create the gateway instance
   shell: /usr/bin/ceph-deploy rgw create cephrgw && echo "done"

--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -2,3 +2,4 @@
 
 - include: install_mons.yml
 - include: install_osds.yml
+- include: install_rgws.yml

--- a/teardown.yml
+++ b/teardown.yml
@@ -10,9 +10,9 @@
 - hosts: cephadmin
   tasks:
     - name: purge ceph
-      shell: ceph-deploy purge cephadmin cephmon cephosd1 cephosd2 cephosd3
+      shell: ceph-deploy purge cephadmin cephmon cephrgw cephosd1 cephosd2 cephosd3
     - name: purge ceph data
-      shell: ceph-deploy purgedata cephadmin cephmon cephosd1 cephosd2 cephosd3
+      shell: ceph-deploy purgedata cephadmin cephmon cephrgw cephosd1 cephosd2 cephosd3
     - name: remove ceph keys
       shell: ceph-deploy forgetkeys
 

--- a/tests/bench.conf
+++ b/tests/bench.conf
@@ -1,0 +1,9 @@
+[bench]
+auth = http://cephrgw:7480/auth/v1.0
+user = testuser:swift
+concurrency = 5
+object_size = 4
+num_objects = 100
+num_gets = 5000
+delete = yes
+auth_version = 1.0

--- a/tests/rgwtest.md
+++ b/tests/rgwtest.md
@@ -1,0 +1,55 @@
+
+## Verify rgw setup
+
+Using `swift-bennch` is an great way to verify the rgw setup
+ * In the cephrgw container create necessary users
+ * On the host pip install swift-bench and it's dependencies
+ * Set up the key, bench.conf
+ * run swift-bench
+
+### Set user
+SSH into a cephrgw node 
+```
+ssh cephrgw
+```
+
+Create the base user and disregard  the output:
+```
+radosgw-admin user create --uid="testuser" --display-name="Testy Tester"
+```
+
+Create the swift user and make note of the secret key
+```
+radosgw-admin subuser create --uid=testuser --subuser=testuser:swift --access=full
+```
+
+~~Sample Output:~~ You will use the secret key ` tB7PSrHReur10oUCiRcgYmXsqRMpPE3oemk5zdaheo ` to run swift-bench on the host
+```
+{
+    ...
+    "swift_keys": [
+        {
+            "user": "testuser:swift",
+            "secret_key": "B7PSrHReur10oUCiRcgYmXsqRMpPE3oemk5zdahe"
+        }
+    ],
+    ...
+}
+```
+
+Install swift-bench and it's dependencies
+```
+sudo apt-get install python-setuptools
+sudo easy_install pip
+sudo pip install --upgrade setuptools
+sudo pip install --upgrade swift-bench
+```
+
+Set the user key and run swift bench
+```
+cd tests
+export SKEY=<swift_keys.secret_key>
+swift-bench -K $SKEY bench.conf
+```
+
+


### PR DESCRIPTION
clearnup.yml is playbook that will stop then destroy the containers, unmount and remove the partitions then shred the disk.    The current teardown.yml will only work if you have a successful install of ceph.    If that errors out for some reason you can use cleanup.yml

Add some docs to the on the bootstrap.sh script and included a command to create a passwordless ssh-key.    

Added the creation of a new container "cephrgw" and installed rgw on it.   There is also a rgw_test.md that will document the testing the rgw gateway using swift-bench.  